### PR TITLE
update to use sf datasets and other V2 tweaks

### DIFF
--- a/03_model-fitting.qmd
+++ b/03_model-fitting.qmd
@@ -1227,10 +1227,10 @@ to specify the number of permutations that are performed to generate the
 envelope for absence of spatial correlation, previously described.
 ```{r}
 #| label: dist-summaries-liberia
-dist_summaries(data = liberia, scale_to_km = TRUE)
+summarise_distance(data = liberia, scale_to_km = TRUE)
 ```
 
-The `dist_summaries()` function within the RiskMap package can be used
+The `summarise_distance()` function within the RiskMap package can be used
 for gauging the extent of the area covered by your dataset, aiding in
 the selection of appropriate values to be passed to the `breaks` argument.
 
@@ -2203,11 +2203,11 @@ to_table(italy_fit, digits = 3)
 
 <!-- ```{r} -->
 
-<!-- dist_summaries(anopheles, scale_to_km = TRUE) -->
+<!-- summarise_distance(anopheles, scale_to_km = TRUE) -->
 
 <!-- ``` -->
 
-<!-- Using the `dist_summaries()` function, we can see that, among the -->
+<!-- Using the `summarise_distance()` function, we can see that, among the -->
 
 <!-- locations of the dataset, the average distance is about 55km and the -->
 

--- a/03_model-fitting.qmd
+++ b/03_model-fitting.qmd
@@ -1343,13 +1343,10 @@ lm_fit <- lm(log(lead) ~ 1, data = galicia)
 # Extract the raw residuals
 galicia$residuals <- lm_fit$residuals
 
-# Convert the galicia data frame into an "sf" object
-galicia_sf <- st_as_sf(galicia, coords = c("x", "y"), crs = 32629)
-
 # Compute the variogram, using the residuals from the linear model fit,
 # and the 95% confidence level envelope for spatial independence
 galicia_variog <- variogram(
-  galicia_sf,
+  galicia,
   variable = "residuals",
   scale_to_km = TRUE,
   breaks = seq(10, 140, length = 15),
@@ -1472,12 +1469,9 @@ these steps is shown below.
 # Incorporating the estimated random effects into the data
 italy_sim$rand_eff <- ranef(lmer_fit)$ID_loc[italy_sim$ID_loc, 1]
 
-# Converting the italy_sim data frame into an "sf" object
-italy_sim_sf <- st_as_sf(italy_sim, coords = c("x1", "x2"), crs = 32634)
-
 # Compute the variogram, using the random effects from the linear mixed model
 # fit, and the 95% confidence level envelope for spatial independence
-italy_sim_variog <- variogram(italy_sim_sf,
+italy_sim_variog <- variogram(italy_sim,
                               variable = "rand_eff",
                               scale_to_km = TRUE,
                               n_permutations = 1000)
@@ -1567,28 +1561,18 @@ function from the RiskMap package. This function implements maximum
 likelihood estimation for generalized linear mixed models using a Matern
 correlation function, while fixing the smoothness parameter $\kappa$ at
 a prespecified value by the user. The object passed to the argument
-`data` in `glpm()` can either be a `data.frame` object or an `sf` object.
-Below we illustrate the use of `glgpm()` while distinguishing between
-these two cases.
+`data` in `glgpm()` must be an `sf` object.
 
-```{r}
-#| label: glgpm-galicia
-# Parameter estimation when the argument passed to `data` is a data-frame
-fit_galicia <- glgpm(log(lead) ~ gp(x, y, kappa = 1.5), 
-                     data = galicia, family = "gaussian", 
-                     crs = 32629, scale_to_km = TRUE, messages = FALSE)
-```
-
-The code above shows the use of `glgpm()` by passing `galicia` as a
-`data.frame` object to `data`. The specification of the Gaussian process
+The specification of the Gaussian process
 $S(x)$ is done through the addition of the term `gp()` in the formula.
-The function `gp()` allows you to specify the columns of the coordinates
-in the data, in this case `x` and `y`, the smoothness parameter through
+The coordinates names in `gp()` in `glgpm()` do not need to be specified 
+as they are both directly obtained from `galicia`. The function `gp()`
+allows you to specify the smoothness parameter through
 the argument `kappa`, set to 1.5 in this example. In the help page of
 `gp()`, you can see that by default the nugget term (denoted in this book
 by the random variable $Z_i$) is excluded from the model by default; to
 include and estimate the variance parameter of the nugget, you should
-set `nugget=NULL` in the `gp()` function. However, doing so for a linear
+set `nugget = TRUE` in the `gp()` function. However, doing so for a linear
 model that only has one observation per location will generate an error
 message as this is a non-identifiable model for the same reasons given
 in @sec-explanal-lm. However, if the measurement error variance is known
@@ -1596,35 +1580,17 @@ this can be fixed by the user using the argument `fix_var_me` and the
 inclusion of the nugget term is then possible (to better understand this
 point, try Exercise 7 at the end of this chapter).
 
-The argument `crs` is used to specify the coordinate reference system
-(CRS) of the data. For the Galicia data, as well as for every other
-dataset used in this book, the CRS is reported in the help page
-description of the dataset. If `crs` is not specified, the function
-will assume that the coordinates are in longitude/latitude format and
-will use these without applying any transformation. Finally, the
-argument `scale_to_km`, is used to specify whether the distances between
+The argument `scale_to_km`, is used to specify whether the distances between
 locations should be scaled to kilometers or maintained in meters; this
 argument will not affect the scale, and thus the interpretation of the
 spatial correlation parameter $\phi$.
 
 ```{r}
 #| label: fit-galicia-sf
-# Parameter estimation when the argument passed to `data` is an sf object
-galicia_sf <- st_as_sf(galicia, coords = c("x", "y"), crs = 32629)
-fit_galicia_sf <- 
-glgpm(log(lead) ~ gp(kappa = 1.5), data = galicia_sf, family = "gaussian",
+fit_galicia <- 
+glgpm(log(lead) ~ gp(kappa = 1.5), data = galicia, family = "gaussian",
       scale_to_km = TRUE, messages = FALSE)
 ```
-
-The code above shows the alternative approach to estimate the model,
-when the argument passed to `data` is an `sf` object. In this case, the
-dataset `galicia` is converted into an `sf` object before the use of
-the `glgpm()` function using `st_as_sf()`. When we then fit the linear
-geostatistical model by passing `galicia_sf` to the argument `data`, the
-only differences with the previous chunk of code that used `galicia`
-instead, is that the coordinates names in `gp()` and the `crs` argument
-in `glgpm()` do not need to be specified as they are both directly
-obtained from `galicia_sf`.
 
 ```{r}
 #| label: summarize-fit-galicia
@@ -1760,11 +1726,6 @@ regions (Admin level 2) and provinces (Admin level 3), as shown in
 #| echo: false
 italy_regions <- readRDS("data/ita_adm2_geoboundaries.rds")
 italy_provinces <- readRDS("data/ita_adm3_geoboundaries.rds")
-italy_sim_sf <- st_as_sf(
-  italy_sim,
-  coords = c("x1", "x2"),
-  crs = 32634
-)
 ```
 
 ```{r}
@@ -1783,14 +1744,14 @@ italy_provinces <- geoboundaries(country = "italy", adm_lvl = "adm3")
 par(mfrow = c(1,2))
 # Map of the data with the region boundaries
 map_regions <- ggplot() + 
-geom_sf(data = italy_sim_sf, pch = 4, color = "red") + 
+geom_sf(data = italy_sim, pch = 4, color = "red") + 
 geom_sf(data = italy_regions, fill = NA) + 
 theme_void() +
 labs(title = "Regions") +
 theme(plot.title = element_text(hjust = 1/2))
 # Map of the data with the province boundaries
 map_provinces <- ggplot() + 
-geom_sf(data = italy_sim_sf, pch = 4, color = "red") + 
+geom_sf(data = italy_sim, pch = 4, color = "red") + 
 geom_sf(data = italy_provinces, fill = NA) + 
 theme_void() +
 labs(title = "Provinces") +
@@ -1835,7 +1796,7 @@ for the province, can be included by using the `re()` function into the
 italy_fit <- glgpm( y ~ log(pop_dens) + gp(kappa = 0.5, nugget = 0) +
                         # Region and province effects
                         re(region, province),
-         data = italy_sim_sf, scale_to_km = TRUE,
+         data = italy_sim, scale_to_km = TRUE,
          family = "gaussian")
 summary(italy_fit)
 ```
@@ -2157,19 +2118,7 @@ to_table(italy_fit, digits = 3)
 
 <!-- $$ {#eq-anopheles} where $d(x_i)$ corresponds to the elevation in meters -->
 
-<!-- at location $x_i$. This time, we first convert the data frame -->
-
-<!-- `anopheles` into an `sf` object. This step is optional but recommended -->
-
-<!-- as it allows us to simplify the code syntax. -->
-
-<!-- ```{r} -->
-
-<!-- anopheles <- st_as_sf(anopheles, coords = c("web_x", "web_y"), -->
-
-<!--                       crs = 3857) -->
-
-<!-- ``` -->
+<!-- at location $x_i$. -->
 
 <!-- We can then use the following script to fit the model in RiskMap. -->
 

--- a/04_geostatistical-prediction.qmd
+++ b/04_geostatistical-prediction.qmd
@@ -237,10 +237,6 @@ res_sim_grid <- readRDS("data/sim_grid_mse.rds")
 
 res_sim_area <- readRDS("data/sim_area_cl.rds")
 
-fit_liberia$sst <- FALSE
-fit_malkenya$sst <- FALSE
-an_fit$sst <- FALSE
-true_model$sst <- FALSE
 ```
 
 ```{r}
@@ -456,8 +452,6 @@ create our new dataset, `malkenya_comm1000`, using the following code.
 #| label: prepare-malkenya-prediction-data
 malkenya_comm1000 <- malkenya_comm[1:1000,]
 
-malkenya_comm1000 <- st_as_sf(malkenya_comm1000, coords = c("Long", "Lat"),
-                              crs = 4326)
 malkenya_comm1000 <- st_transform(malkenya_comm1000, crs = 32736)
 ```
 

--- a/05_case-studies.qmd
+++ b/05_case-studies.qmd
@@ -217,7 +217,7 @@ To fit this model, we create a cluster ID variable based on the sampling coordin
 #| label: identify-malnutrition-locations
 # Create ID for the location
 malnutrition <- malnutrition %>%
-  group_by(lng, lat) %>%
+  group_by(geometry) %>%
   mutate(loc_id = cur_group_id()) %>%
   ungroup()
 ```
@@ -254,17 +254,16 @@ re <- data.frame(
   Z_hat_waz = ranef(waz_lmer)$loc_id[,1]
 )
 
-# Extract one row per location with coordinates
+# Extract one row per location 
 loc_coords <- malnutrition %>%
-  select(loc_id, lng, lat) %>%
+  select(loc_id) %>%
   distinct()
 
 # Merge coordinates into random effects
-re <- left_join(re, loc_coords, by = "loc_id")
+re <- left_join(loc_coords, re, by = "loc_id")
 
-# Convert to sf and transform into UTM
+# Transform into UTM
 library(sf)
-re <- st_as_sf(re, coords = c("lng","lat"), crs = 4326)
 re <- st_transform(re, crs = propose_utm(re))
 
 # Variogram for HAZ

--- a/05_case-studies.qmd
+++ b/05_case-studies.qmd
@@ -301,18 +301,17 @@ where $S(x)$ is a zero-mean, stationary, and isotropic Gaussian process with var
 # Remove missing data from the WAZ outcome
 malnutrition <- malnutrition[complete.cases(malnutrition[,"WAZ"]),]
 
-# Converting the data-frame into an sf object
-malnutrition_sf <- st_as_sf(malnutrition, coords = c("lng", "lat"), crs = 4326)
-malnutrition_sf <- st_transform(malnutrition_sf, crs = propose_utm(malnutrition_sf))
+# Reproject the data
+malnutrition <- st_transform(malnutrition, crs = propose_utm(malnutrition))
 
 # Maximum likelihood estimation for the HAZ and WAZ outcomes
 haz_fit <- 
 glgpm(HAZ ~ age + pmax(age - 1, 0) + wealth + gp(),
-      data=malnutrition_sf, family = "gaussian")
+      data = malnutrition, family = "gaussian")
 
 waz_fit <- 
-  glgpm(HAZ ~ age + pmax(age - 1, 0) + wealth + gp(),
-        data=malnutrition_sf, family = "gaussian") 
+  glgpm(WAZ ~ age + pmax(age - 1, 0) + wealth + gp(),
+        data = malnutrition, family = "gaussian") 
 ```
 
 We then summarize the fit of models.
@@ -346,7 +345,7 @@ To implement this in RiskMap, we begin by generating a predictive grid over the 
 # Boundaries of Ghana
 library(rgeoboundaries)
 ghana <- geoboundaries(country = "Ghana", adm_lvl = "adm0")
-ghana <- st_transform(ghana, st_crs(malnutrition_sf))
+ghana <- st_transform(ghana, st_crs(malnutrition))
 
 ghana_grid <- create_grid(ghana, spat_res = 10)
 
@@ -1185,8 +1184,6 @@ abund_sma$year <- as.numeric(substr(abund_sma$date, 1, 4))
 
 # bbox for coord_sf limits
 bb <- st_bbox(sma_boundaries)
-abund_sma <- st_as_sf(abund_sma, coords = c("lon","lat"), crs = 4326, remove = FALSE)
-
 
 # Panel 1: faceted map, colored by trap_group (scales fixed!)
 p_locs <- ggplot() +
@@ -1429,13 +1426,12 @@ and a default conservative value, such as 25, is used if no nearby collections a
 
 The data comprise 596 responses, of which only 18 pools test positive. This very low prevalence constrains our modelling choices, for example by limiting the feasibility of incorporating temporal dynamics. As a result, the model in @eq-wnv-pos-model represents the simplest specification that can still capture spatial correlation, under the simplifying assumption that WNV risk remains relatively stable over the study period. Furthermore, because there is only a single binary outcome per location, overdispersion cannot occur (see box “Why Bernoulli extra‐variation does not exist” in Section 5.1.1 of @diggleBook2019), and the empirical variogram provides limited value for assessing spatial correlation due to its high uncertainty in this context. We therefore proceed directly to fitting a geostatistical model and assess the estimate of the spatial correlation parameter, which quantifies the strength and range of spatial dependence in the data.
 
-We then proceed in R as follows. We first load the data and convert them into an `sf` object with the appropriate UTM projection. 
+We then proceed in R as follows. We first load the data and convert them to an appropriate UTM projection. 
 ```{r}
 #| label: prepare-wnv-infection-data
 #| eval: false
 data(infect_sma)
 
-infect_sma <- st_as_sf(infect_sma, coords = c("lon", "lat"), crs = 4326)
 wnv_crs <- propose_utm(infect_sma)
 infect_sma <- st_transform(infect_sma, wnv_crs)
 ```
@@ -1457,11 +1453,10 @@ inf_fit <- readRDS("data/inf_fit.rds")
 #| label: fit-wnv-infection-model
 #| eval: false
 inf_fit <-
-  glgpm(wnv_pos ~ gp(lon,lat),
-        crs = wnv_crs,
+  glgpm(wnv_pos ~ gp(),
         family = "binomial",
         invlink = invlink_wnv,
-        data=infect_sma)
+        data = infect_sma)
 ```
 Finally, we examine the the summary of the fitted model. 
 ```{r}
@@ -1522,8 +1517,8 @@ Finally, we predict the vector index as defined in @eq-vi. Because *Cx. pipiens*
 #| label: predict-wnv-infection
 #| eval: false
 
-# Converting the abund_sma into an sf object
-loc_pred <- st_as_sfc(st_transform(st_as_sf(abund_sma, coords = c("lon","lat"), crs = 4326), crs = wnv_crs))
+# Transform abund_sma into the same projection as infect_sma
+loc_pred <- st_transform(abund_sma, crs = wnv_crs)
 
 # Prediction of the spatial process S(x) over the locations of the 
 # abund_sma dataset


### PR DESCRIPTION
I think this should all run with V2 now.

It is mostly renaming variables and removing df > sf but I have edited the text as well.

I don't know if you want to add a bit somewhere about all the data being sf apart from `liberia`? And maybe link back to Section 2 where I removed the df > sf conversion of `galicia`?