### PR TITLE
Prevent stale Quarto freeze records from being merged

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Summary
+
+Describe the purpose and scope of the change.
+
+## Verification
+
+- [ ] I followed `CONTRIBUTING.md` and `STYLE_GUIDE.md`.
+- [ ] I rendered and inspected every changed chapter.
+- [ ] I committed matching `_freeze/` records for every changed executable
+      chapter, including changes to reader-visible code in `eval: false`
+      chunks.
+- [ ] I inspected format-sensitive changes in both HTML and PDF.
+- [ ] I excluded `docs/`, caches, local settings, credentials, and unrelated
+      generated files.
+
+If this is a genuinely prose-only change for which the freeze output cannot
+change, explain why and ask a maintainer to apply the `freeze-not-required`
+label after review.

--- a/.github/workflows/check-freeze.yml
+++ b/.github/workflows/check-freeze.yml
@@ -1,0 +1,26 @@
+name: Check Quarto freeze records
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  check-freeze:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Test the freeze safeguard
+        run: scripts/test-check-freeze.sh
+
+      - name: Check changed chapters
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          FREEZE_NOT_REQUIRED: ${{ contains(github.event.pull_request.labels.*.name, 'freeze-not-required') }}
+        run: scripts/check-freeze.sh "$BASE_SHA" "$HEAD_SHA" "$FREEZE_NOT_REQUIRED"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,22 @@ When changing a chapter:
 3. Commit the updated `.qmd` file and the corresponding `_freeze/` results.
 4. Do not commit `docs/`, `*_files/`, `site_libs/`, or `*_cache/`.
 
+This requirement also applies when reader-visible code changes inside an
+`eval: false` chunk: the displayed source is stored in the freeze record even
+though R does not execute it. Pull requests are checked automatically and an
+executable chapter without a matching change under
+`_freeze/<chapter>/execute-results/` will fail the freeze check.
+
+For a genuinely prose-only change that cannot affect computational or
+reader-visible frozen output, explain the exception in the pull request. A
+maintainer may then apply the `freeze-not-required` label after reviewing the
+rendered chapter. Do not use the label for code, dependency, input-data, or
+saved-object changes.
+
+The automated check deliberately does not run scientific computations. It is
+a lightweight safeguard against mismatched source and freeze records, not a
+replacement for rendering and inspecting the chapter locally.
+
 Use cache only for a specific deterministic chunk that benefits materially
 from it. Do not enable cache for an entire chapter by default. Cache is a local
 performance aid; it is not a reproducibility mechanism and is not committed.
@@ -159,6 +175,11 @@ being recomputed.
 
 If a `.qmd` file changes without matching frozen results, update `_freeze/`
 locally before merging.
+
+A full local refresh may also be required when a dependency, input dataset, or
+precomputed object changes without a corresponding `.qmd` edit. The automated
+freeze check cannot infer those relationships, so contributors must describe
+and verify them explicitly in the pull request.
 
 The repository's GitHub Pages source must be set to **GitHub Actions**, and the
 custom domain must be configured as `www.mbgr.org` in the repository Pages

--- a/scripts/check-freeze.sh
+++ b/scripts/check-freeze.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+base_ref=${1:?Usage: check-freeze.sh BASE_REF HEAD_REF [ALLOW_EXCEPTION]}
+head_ref=${2:?Usage: check-freeze.sh BASE_REF HEAD_REF [ALLOW_EXCEPTION]}
+allow_exception=${3:-false}
+
+if [[ "$allow_exception" == "true" ]]; then
+  echo "Skipping the freeze check because the freeze-not-required label is present."
+  exit 0
+fi
+
+mapfile -t changed_files < <(
+  git diff --name-only --diff-filter=ACMR "$base_ref" "$head_ref"
+)
+
+missing_freeze=()
+
+for source_file in "${changed_files[@]}"; do
+  [[ "$source_file" == *.qmd ]] || continue
+  [[ -f "$source_file" ]] || continue
+
+  chapter_name=${source_file%.qmd}
+  freeze_prefix="_freeze/${chapter_name}/execute-results/"
+
+  if ! grep -Eq '^`{3,}\{r([,[:space:]}])' "$source_file" &&
+     [[ ! -d "_freeze/${chapter_name}/execute-results" ]]; then
+    continue
+  fi
+
+  freeze_changed=false
+  for changed_file in "${changed_files[@]}"; do
+    if [[ "$changed_file" == "$freeze_prefix"* ]]; then
+      freeze_changed=true
+      break
+    fi
+  done
+
+  if [[ "$freeze_changed" == "false" ]]; then
+    missing_freeze+=("$source_file")
+  fi
+done
+
+if (( ${#missing_freeze[@]} > 0 )); then
+  echo "The following executable chapters changed without matching freeze records:"
+  printf '  - %s\n' "${missing_freeze[@]}"
+  echo
+  echo "Render each listed chapter locally and commit its matching"
+  echo "_freeze/<chapter>/execute-results/ files."
+  echo
+  echo "For a genuinely prose-only change, ask a maintainer to apply the"
+  echo "freeze-not-required label after reviewing the rendered effect."
+  exit 1
+fi
+
+echo "All changed executable chapters have matching freeze-record changes."

--- a/scripts/test-check-freeze.sh
+++ b/scripts/test-check-freeze.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+checker=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/check-freeze.sh
+test_repo=$(mktemp -d)
+trap 'rm -rf "$test_repo"' EXIT
+
+git -C "$test_repo" init --quiet
+git -C "$test_repo" config user.name "Freeze check test"
+git -C "$test_repo" config user.email "freeze-check@example.invalid"
+
+mkdir -p "$test_repo/_freeze/01_example/execute-results"
+printf '%s\n' '```{r}' '1 + 1' '```' > "$test_repo/01_example.qmd"
+printf '%s\n' '{"hash":"initial"}' \
+  > "$test_repo/_freeze/01_example/execute-results/html.json"
+git -C "$test_repo" add .
+git -C "$test_repo" commit --quiet -m "Initial chapter"
+base_commit=$(git -C "$test_repo" rev-parse HEAD)
+
+printf '%s\n' '' 'Updated explanation.' >> "$test_repo/01_example.qmd"
+git -C "$test_repo" add 01_example.qmd
+git -C "$test_repo" commit --quiet -m "Change chapter only"
+stale_commit=$(git -C "$test_repo" rev-parse HEAD)
+
+if (cd "$test_repo" && "$checker" "$base_commit" "$stale_commit"); then
+  echo "Expected a chapter-only change to fail the freeze check."
+  exit 1
+fi
+
+(cd "$test_repo" && "$checker" "$base_commit" "$stale_commit" true)
+
+printf '%s\n' '{"hash":"updated"}' \
+  > "$test_repo/_freeze/01_example/execute-results/html.json"
+git -C "$test_repo" add _freeze
+git -C "$test_repo" commit --quiet -m "Refresh freeze"
+complete_commit=$(git -C "$test_repo" rev-parse HEAD)
+
+(cd "$test_repo" && "$checker" "$base_commit" "$complete_commit")
+
+echo "Freeze-check tests passed."


### PR DESCRIPTION
## Summary

- add a lightweight pull-request check requiring matching freeze records for changed executable chapters
- provide a maintainer-reviewed `freeze-not-required` exception for genuinely prose-only changes
- add a pull-request checklist aligned with the contributing guide
- document when chapter, dependency, data, and saved-object changes require local refreshes

## Verification

- the self-test confirms that a source-only chapter change fails
- the self-test confirms that a matching freeze change passes
- the self-test confirms that the reviewed exception passes
- the checker detects the historical Chapter 3–5 stale-freeze mismatch from PR #35
- the workflow does not execute R or regenerate scientific outputs
- `git diff --check` passes

Closes #47